### PR TITLE
Fix Tailwind config location

### DIFF
--- a/components.json
+++ b/components.json
@@ -4,7 +4,7 @@
     "rsc": false,
     "tsx": true,
     "tailwind": {
-      "config": "tailwind.config.ts",
+      "config": "tailwind.config.js",
       "css": "client/src/index.css",
       "baseColor": "neutral",
       "cssVariables": true,

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "dev": "NODE_ENV=development tsx server/index.ts",
-    "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
+    "build": "TAILWIND_CONFIG=tailwind.config.js vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
     "db:push": "drizzle-kit push"

--- a/server/middleware/authMiddleware.ts
+++ b/server/middleware/authMiddleware.ts
@@ -32,7 +32,8 @@ export const requireAuth = async (req: Request, res: Response, next: NextFunctio
       }
       
       // If MongoDB not connected or user not found, try memory storage
-        const user = await storage.getUser(req.session.userId);
+      const sessionId = typeof req.session.userId === 'string' ? parseInt(req.session.userId, 10) : req.session.userId;
+      const user = await storage.getUser(sessionId);
       
       if (user) {
         req.user = {

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -1,7 +1,10 @@
 import express, { type Express } from "express";
 import fs from "fs";
 import path from "path";
-import { createServer as createViteServer, createLogger, type ServerOptions } from "vite";
+import * as vite from "vite";
+const createViteServer = vite.createServer;
+const createLogger = vite.createLogger;
+type ServerOptions = vite.ServerOptions;
 import { type Server } from "http";
 import viteConfig from "../vite.config";
 import { nanoid } from "nanoid";

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,8 +1,8 @@
-import type { Config } from "tailwindcss";
 import animate from "tailwindcss-animate";
 import typography from "@tailwindcss/typography";
 
-const config: Config = {
+/** @type {import('tailwindcss').Config} */
+const config = {
   darkMode: ["class"],
   content: ["./client/index.html", "./client/src/**/*.{js,jsx,ts,tsx}"],
   theme: {
@@ -15,6 +15,7 @@ const config: Config = {
       colors: {
         background: "hsl(var(--background))",
         foreground: "hsl(var(--foreground))",
+        border: "hsl(var(--border))",
         card: {
           DEFAULT: "hsl(var(--card))",
           foreground: "hsl(var(--card-foreground))",
@@ -41,3 +42,4 @@ const config: Config = {
 };
 
 export default config;
+


### PR DESCRIPTION
## Summary
- convert `tailwind.config.ts` to JavaScript and move to repo root
- add `border` color so `border-border` utility works
- update build script and shadcn config
- patch server build errors by using a namespace import in `server/vite.ts`
- fix type issue in auth middleware

## Testing
- `npm run check`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68408bb5f84c83318155552e161db36c