### PR TITLE
Adapt server for Vercel serverless

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ For production deployment:
 
 This will serve the static client files and the API from a single Express server.
 
+## Deploying to Vercel
+
+A serverless handler is provided at `api/[...route].ts` which wraps the Express application for Vercel's Node.js runtime. After running `npm run build` in the `server` directory, deploy the repository root on Vercel and the API will be available under `/api/*`. The client can still be deployed separately from the `client` folder using its own `vercel.json`.
+
 ## Credits
 
-Built for a local Moroccan tour agency to showcase their authentic experiences and streamline their booking process.
+Built for a local Moroccan tour agency to showcase their authentic experiences and streamline their booking process

--- a/api/[...route].ts
+++ b/api/[...route].ts
@@ -1,0 +1,8 @@
+import { createApp } from '../server/app';
+
+const appPromise = createApp();
+
+export default async function handler(req: any, res: any) {
+  const app = await appPromise;
+  return app(req, res);
+}

--- a/server/app.ts
+++ b/server/app.ts
@@ -1,0 +1,85 @@
+import express, { type Request, type Response, type NextFunction, type Express } from 'express';
+import { registerRoutes } from './routes';
+import { log } from './vite';
+import path from 'path';
+import connectToDatabase from './config/database';
+import cors from 'cors';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+export async function createApp(): Promise<Express> {
+  const app = express();
+  app.use(express.json());
+  app.use(express.urlencoded({ extended: false }));
+
+  const allowedOrigins = [
+    'http://localhost:3000',
+    'http://127.0.0.1:3000',
+    process.env.CLIENT_URL || 'https://marrakech-deserts.vercel.app'
+  ];
+
+  app.use(cors({
+    origin: function(origin: string | undefined, callback: (err: Error | null, allow?: boolean) => void) {
+      if (!origin) return callback(null, true);
+      if (allowedOrigins.indexOf(origin) === -1) {
+        const msg = 'The CORS policy for this site does not allow access from the specified Origin.';
+        return callback(new Error(msg), false);
+      }
+      return callback(null, true);
+    },
+    credentials: true
+  }));
+
+  app.get('/api/health', (_req, res) => {
+    res.status(200).json({ status: 'ok', timestamp: new Date().toISOString() });
+  });
+
+  app.use('/attached_assets', express.static(path.join(process.cwd(), 'attached_assets')));
+
+  app.use((req, res, next) => {
+    const start = Date.now();
+    const reqPath = req.path;
+    let captured: Record<string, any> | undefined;
+
+    const original = res.json.bind(res);
+    res.json = function(body, ...args) {
+      captured = body;
+      return original(body, ...args);
+    } as any;
+
+    res.on('finish', () => {
+      const duration = Date.now() - start;
+      if (reqPath.startsWith('/api')) {
+        let line = `${req.method} ${reqPath} ${res.statusCode} in ${duration}ms`;
+        if (captured) line += ` :: ${JSON.stringify(captured)}`;
+        if (line.length > 80) line = line.slice(0, 79) + '…';
+        log(line);
+      }
+    });
+
+    next();
+  });
+
+  connectToDatabase().then(connected => {
+    if (connected) {
+      log('MongoDB integration is active', 'mongodb');
+    } else {
+      log('Running without MongoDB support - using memory storage only', 'mongodb');
+    }
+  }).catch(error => {
+    log(`Failed to initialize MongoDB: ${error}`, 'mongodb');
+    log('Continuing with memory storage only', 'mongodb');
+  });
+
+  await registerRoutes(app);
+
+  app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {
+    const status = err.status || err.statusCode || 500;
+    const message = err.message || 'Internal Server Error';
+    res.status(status).json({ message });
+    throw err;
+  });
+
+  return app;
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,119 +1,19 @@
-import express, { type Request, Response, NextFunction } from "express";
-import { registerRoutes } from "./routes";
-import { setupVite, serveStatic, log } from "./vite";
-import path from "path";
-import connectToDatabase from './config/database';
-import cors from 'cors';
-import dotenv from 'dotenv';
-import type { CorsOptions, CorsRequest } from 'cors';
-
-// Load environment variables
-dotenv.config();
-
-const app = express();
-app.use(express.json());
-app.use(express.urlencoded({ extended: false }));
-
-// Configure CORS
-const allowedOrigins = [
-  'http://localhost:3000',
-  'http://127.0.0.1:3000',
-  process.env.CLIENT_URL || 'https://marrakech-deserts.vercel.app'
-];
-
-app.use(cors({
-  origin: function(origin: string | undefined, callback: (err: Error | null, allow?: boolean) => void) {
-    // Allow requests with no origin (like mobile apps, curl requests)
-    if (!origin) return callback(null, true);
-    
-    if (allowedOrigins.indexOf(origin) === -1) {
-      const msg = 'The CORS policy for this site does not allow access from the specified Origin.';
-      return callback(new Error(msg), false);
-    }
-    return callback(null, true);
-  },
-  credentials: true
-}));
-
-// Health check endpoint for Railway deployment
-app.get('/api/health', (req, res) => {
-  res.status(200).json({ status: 'ok', timestamp: new Date().toISOString() });
-});
-
-// Serve static files from the project root
-app.use('/attached_assets', express.static(path.join(process.cwd(), 'attached_assets')));
-
-app.use((req, res, next) => {
-  const start = Date.now();
-  const path = req.path;
-  let capturedJsonResponse: Record<string, any> | undefined = undefined;
-
-  const originalResJson = res.json;
-  res.json = function (bodyJson, ...args) {
-    capturedJsonResponse = bodyJson;
-    return originalResJson.apply(res, [bodyJson, ...args]);
-  };
-
-  res.on("finish", () => {
-    const duration = Date.now() - start;
-    if (path.startsWith("/api")) {
-      let logLine = `${req.method} ${path} ${res.statusCode} in ${duration}ms`;
-      if (capturedJsonResponse) {
-        logLine += ` :: ${JSON.stringify(capturedJsonResponse)}`;
-      }
-
-      if (logLine.length > 80) {
-        logLine = logLine.slice(0, 79) + "…";
-      }
-
-      log(logLine);
-    }
-  });
-
-  next();
-});
+import { createServer } from 'http';
+import { setupVite, serveStatic, log } from './vite';
+import { createApp } from './app';
 
 (async () => {
-  // Attempt to connect to MongoDB, but continue regardless of result
-  connectToDatabase().then(connected => {
-    if (connected) {
-      log('MongoDB integration is active', 'mongodb');
-    } else {
-      log('Running without MongoDB support - using memory storage only', 'mongodb');
-    }
-  }).catch(error => {
-    log(`Failed to initialize MongoDB: ${error}`, 'mongodb');
-    log('Continuing with memory storage only', 'mongodb');
-  });
-  
-  const server = await registerRoutes(app);
+  const app = await createApp();
+  const server = createServer(app);
 
-  app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {
-    const status = err.status || err.statusCode || 500;
-    const message = err.message || "Internal Server Error";
-
-    res.status(status).json({ message });
-    throw err;
-  });
-
-  // importantly only setup vite in development and after
-  // setting up all the other routes so the catch-all route
-  // doesn't interfere with the other routes
-  if (app.get("env") === "development") {
+  if (app.get('env') === 'development') {
     await setupVite(app, server);
   } else {
     serveStatic(app);
   }
 
-  // ALWAYS serve the app on port 5000
-  // this serves both the API and the client.
-  // It is the only port that is not firewalled.
   const port = 5000;
-  server.listen({
-    port,
-    host: "0.0.0.0",
-    reusePort: true,
-  }, () => {
+  server.listen({ port, host: '0.0.0.0', reusePort: true }, () => {
     log(`serving on port ${port}`);
   });
 })();


### PR DESCRIPTION
## Summary
- refactor Express setup into `createApp`
- simplify `server/index.ts` and use `createApp`
- add Vercel serverless handler `api/[...route].ts`
- document Vercel deployment instructions in README

## Testing
- `npm run build`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6842c50a1c6c8331b723b19356ccadf1