### PR TITLE
Potential fix for code scanning alert no. 33: Missing rate limiting

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -540,7 +540,12 @@ export async function registerRoutes(app: Express): Promise<Server> {
   });
 
   // Audit logs route (superadmin only)
-  app.get("/api/admin/audit-logs", requireAuth, requireSuperAdmin, async (req, res) => {
+  const auditLogsRateLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 50, // Limit each superadmin to 50 requests per windowMs
+  });
+
+  app.get("/api/admin/audit-logs", requireAuth, requireSuperAdmin, auditLogsRateLimiter, async (req, res) => {
     try {
       const logs = await storage.getAuditLogs();
       res.json(logs);


### PR DESCRIPTION
Potential fix for [https://github.com/hamzaRio/MarrakechTours/security/code-scanning/33](https://github.com/hamzaRio/MarrakechTours/security/code-scanning/33)

To fix the issue, we will add a rate-limiting middleware to the `/api/admin/audit-logs` route. This middleware will limit the number of requests a superadmin can make to this endpoint within a specified time window. We will use the `express-rate-limit` package, which is already imported in the file, to define and apply the rate limiter. The rate limiter will be configured similarly to the one used for `/api/admin/users`, with a limit of 50 requests per 15 minutes.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
