### PR TITLE
Add user rate limiter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
         "drizzle-zod": "^0.7.1",
         "embla-carousel-react": "^8.6.0",
         "express": "^4.21.2",
+        "express-rate-limit": "^7.5.0",
         "express-session": "^1.18.1",
         "framer-motion": "^11.13.1",
         "i18next": "^25.1.2",
@@ -5833,6 +5834,21 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz",
+      "integrity": "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": "^4.11 || 5 || ^5.0.0-beta.1"
       }
     },
     "node_modules/express-session": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "drizzle-zod": "^0.7.1",
     "embla-carousel-react": "^8.6.0",
     "express": "^4.21.2",
+    "express-rate-limit": "^7.5.0",
     "express-session": "^1.18.1",
     "framer-motion": "^11.13.1",
     "i18next": "^25.1.2",

--- a/server/app.ts
+++ b/server/app.ts
@@ -42,8 +42,8 @@ export async function createApp(): Promise<Express> {
     const reqPath = req.path;
     let captured: Record<string, any> | undefined;
 
-    const original = res.json.bind(res);
-    res.json = function(body, ...args) {
+    const original = res.json.bind(res) as (body?: any, ...args: any[]) => typeof res;
+    res.json = function (body?: any, ...args: any[]): typeof res {
       captured = body;
       return original(body, ...args);
     } as any;

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -18,6 +18,15 @@ import { isMongoConnected } from './config/database';
 import { getActivityCapacity, getDateCapacity } from './controllers/capacityController';
 import { setupAuth, requireAuth, requireAdmin, requireSuperAdmin } from './auth';
 
+const userRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 50, // Limit each user to 50 requests per windowMs
+  keyGenerator: (req: Request): string => {
+    const user = req.user as Express.User | undefined;
+    return user?.id ? String(user.id) : req.ip || "";
+  }
+});
+
 export async function registerRoutes(app: Express): Promise<Server> {
   // Set up authentication (includes session configuration)
   setupAuth(app);
@@ -107,7 +116,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
-  app.post("/api/activities", requireAuth, async (req, res) => {
+  app.post("/api/activities", requireAuth, userRateLimiter, async (req, res) => {
     try {
       const validatedData = insertActivitySchema.parse(req.body);
       const activity = await storage.createActivity(validatedData);
@@ -132,7 +141,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
-  app.patch("/api/activities/:id", requireAuth, async (req, res) => {
+  app.patch("/api/activities/:id", requireAuth, userRateLimiter, async (req, res) => {
     try {
       const id = parseInt(req.params.id);
       const oldActivity = await storage.getActivity(id);
@@ -167,7 +176,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
-  app.delete("/api/activities/:id", requireAuth, async (req, res) => {
+  app.delete("/api/activities/:id", requireAuth, userRateLimiter, async (req, res) => {
     try {
       const id = parseInt(req.params.id);
       const activity = await storage.getActivity(id);
@@ -196,7 +205,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   });
 
   // Booking routes
-  app.get("/api/bookings", requireAuth, async (req, res) => {
+  app.get("/api/bookings", requireAuth, userRateLimiter, async (req, res) => {
     try {
       const bookings = await storage.getAllBookings();
       res.json(bookings);
@@ -205,7 +214,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
-  app.get("/api/bookings/:id", requireAuth, async (req, res) => {
+  app.get("/api/bookings/:id", requireAuth, userRateLimiter, async (req, res) => {
     try {
       const id = parseInt(req.params.id);
       const booking = await storage.getBooking(id);
@@ -221,7 +230,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   });
   
   // Endpoint to manually sync a booking with CRM
-  app.post("/api/bookings/:id/sync-crm", requireAuth, async (req, res) => {
+  app.post("/api/bookings/:id/sync-crm", requireAuth, userRateLimiter, async (req, res) => {
     try {
       const bookingId = parseInt(req.params.id);
       const booking = await storage.getBooking(bookingId);
@@ -279,7 +288,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   });
   
   // Endpoint to resend WhatsApp notification for a specific booking
-  app.post("/api/bookings/:id/resend-whatsapp", requireAuth, async (req, res) => {
+  app.post("/api/bookings/:id/resend-whatsapp", requireAuth, userRateLimiter, async (req, res) => {
     try {
       const bookingId = parseInt(req.params.id);
       const booking = await storage.getBooking(bookingId);
@@ -430,7 +439,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   });
 
   // Update booking status specifically
-  app.patch("/api/bookings/:id/status", requireAuth, async (req, res) => {
+  app.patch("/api/bookings/:id/status", requireAuth, userRateLimiter, async (req, res) => {
     try {
       const id = parseInt(req.params.id);
       const { status } = req.body;
@@ -476,7 +485,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
   
-  app.patch("/api/bookings/:id", requireAuth, async (req, res) => {
+  app.patch("/api/bookings/:id", requireAuth, userRateLimiter, async (req, res) => {
     try {
       const id = parseInt(req.params.id);
       const oldBooking = await storage.getBooking(id);
@@ -511,7 +520,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
-  app.delete("/api/bookings/:id", requireAuth, async (req, res) => {
+  app.delete("/api/bookings/:id", requireAuth, userRateLimiter, async (req, res) => {
     try {
       const id = parseInt(req.params.id);
       const booking = await storage.getBooking(id);
@@ -545,7 +554,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
     max: 50, // Limit each superadmin to 50 requests per windowMs
   });
 
-  app.get("/api/admin/audit-logs", requireAuth, requireSuperAdmin, auditLogsRateLimiter, async (req, res) => {
+  app.get("/api/admin/audit-logs", requireAuth, userRateLimiter, requireSuperAdmin, auditLogsRateLimiter, async (req, res) => {
     try {
       const logs = await storage.getAuditLogs();
       res.json(logs);
@@ -555,7 +564,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   });
 
   // Current user route
-  app.get("/api/me", requireAuth, async (req, res) => {
+  app.get("/api/me", requireAuth, userRateLimiter, async (req, res) => {
     try {
       if (!req.user?.id) {
         return res.status(401).json({ message: "Not authenticated" });
@@ -577,11 +586,6 @@ export async function registerRoutes(app: Express): Promise<Server> {
   });
   
   // Get all users (only for superadmin)
-  const userRateLimiter = rateLimit({
-    windowMs: 15 * 60 * 1000, // 15 minutes
-    max: 50, // Limit each superadmin to 50 requests per windowMs
-  });
-
   app.get("/api/admin/users", requireAuth, requireSuperAdmin, userRateLimiter, async (req, res) => {
     try {
       // Get all users from storage - this would be implemented in a real storage solution
@@ -611,7 +615,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   });
   
   // WhatsApp notification stats endpoint (admin only)
-  app.get("/api/admin/notification-stats", requireAuth, async (req, res) => {
+  app.get("/api/admin/notification-stats", requireAuth, userRateLimiter, async (req, res) => {
     try {
       const { getNotificationStats } = await import('./utils/notificationStats');
       const stats = getNotificationStats();


### PR DESCRIPTION
## Summary
- implement reusable userRateLimiter middleware using express-rate-limit
- apply middleware to all authenticated routes
- adjust server middleware typing
- add express-rate-limit dependency

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_684462d603008331a9cc3195b1584bcf